### PR TITLE
Fix interactive mode defects

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,7 +92,7 @@ Deslopify - Clean up text by removing/translating common "slop" patterns
 Usage: deslopify [options]
 
 Options:
-  -i, --input <file>         Input file (if not provided, reads from stdin)
+  --input <file>              Input file (if not provided, reads from stdin)
   -o, --output <file>        Output file (if not provided, writes to stdout)
   --skip-chars               Skip character replacements
   --skip-phrases             Skip phrase removals
@@ -107,7 +107,7 @@ Options:
   --no-preserve-codeblocks   Don't preserve whitespace in code blocks
   --remove-all-emoji         Remove all emoji characters from text
   --remove-overused-emoji    Remove commonly overused emoji and emoji clusters
-  -i, --interactive          Launch interactive mode to process text from clipboard
+  --interactive              Launch interactive mode to process text from clipboard
   -h, --help                 Show this help message
   
 Examples:
@@ -116,7 +116,7 @@ Examples:
   deslopify --paragraph-spacing double < input.txt > output.txt
   cat input.txt | deslopify > output.txt
   deslopify --remove-all-emoji < input.txt > output.txt
-  deslopify --interactive
+  deslopify --interactive       # Start interactive mode (type 'q' to quit)
   `);
 }
 

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -39,7 +39,9 @@ export class InteractiveMode {
   private showWelcomeMessage(): void {
     console.log(chalk.bold(chalk.green('\n=== Deslopifier Interactive Mode ===\n')));
     console.log(`Paste text to process it, or type ${chalk.cyan('h')} for help.`);
-    console.log(`Processed text will be copied to your clipboard automatically.\n`);
+    console.log('For multiline input, paste all at once or enter line by line. Press Enter on an empty line to finish.');
+    console.log(`Type ${chalk.cyan('q')} to quit the interactive mode.`);
+    console.log('Processed text will be copied to your clipboard automatically.\n');
   }
 
   /**
@@ -47,12 +49,12 @@ export class InteractiveMode {
    */
   private showHelp(): void {
     console.log(chalk.bold(chalk.yellow('\n=== HELP ===\n')));
-    console.log(`${chalk.cyan('q')}: Quit interactive mode`);
+    console.log(`${chalk.cyan('q')}: Quit interactive mode (recommended way to exit)`);
     console.log(`${chalk.cyan('h')}: Show this help information`);
     console.log(`${chalk.cyan('v')}: Toggle verbose mode`);
     console.log(`${chalk.cyan('b')}: Toggle batch mode`);
     console.log(`${chalk.cyan('c')}: Clear input buffer`);
-    console.log(`${chalk.cyan('Ctrl+C')}: Exit immediately\n`);
+    console.log(`${chalk.cyan('Ctrl+C')}: Exit immediately (may not work in all terminals)\n`);
     
     console.log(`${chalk.bold('Batch Mode')}: When enabled, stays in input mode after processing`);
     console.log(`${chalk.bold('Verbose Mode')}: When enabled, shows additional processing details\n`);
@@ -70,14 +72,47 @@ export class InteractiveMode {
     
     while (this.running) {
       console.log(chalk.green('Waiting for input...') + chalk.dim(' (Paste text or type a command)'));
+      console.log(chalk.dim('For multiline input, paste all text at once or enter line by line. Press Enter on empty line to finish.'));
       
-      // Get input from user
-      const input = readlineSync.question('> ');
+      // Get initial input from user
+      let input = '';
+      const line = readlineSync.question('> ');
       
       // Check if it's a single character command
-      if (input.length === 1) {
-        this.handleKeyPress(input);
+      if (line.length === 1) {
+        this.handleKeyPress(line);
         continue;
+      }
+      
+      // If it's not a command, collect all input
+      input = line;
+      
+      // Allow the user to continue pasting or adding more lines
+      // Keep reading lines until an empty line is entered
+      let multilineInput = false;
+      
+      if (input.includes('\n')) {
+        // Handle pasted multiline text
+        multilineInput = true;
+      } else {
+        console.log(chalk.dim('Continue entering text, or press Enter on an empty line to finish:'));
+        
+        let collectingInput = true;
+        while (collectingInput) {
+          const additionalLine = readlineSync.question('');
+          
+          // Empty line signals end of input
+          if (additionalLine.trim() === '') {
+            collectingInput = false;
+          } else {
+            input += '\n' + additionalLine;
+            multilineInput = true;
+          }
+        }
+      }
+      
+      if (multilineInput) {
+        console.log(chalk.dim('Processing multiline input...'));
       }
       
       // Process the text
@@ -119,6 +154,19 @@ export class InteractiveMode {
     process.on('SIGINT', () => {
       console.log(chalk.yellow('\nExiting interactive mode. Goodbye!'));
       process.exit(0);
+    });
+    
+    // Handle process termination signals
+    process.on('SIGTERM', () => {
+      console.log(chalk.yellow('\nProcess terminated. Exiting interactive mode.'));
+      process.exit(0);
+    });
+
+    // Handle uncaught exceptions
+    process.on('uncaughtException', (error) => {
+      console.error(chalk.red('\nAn error occurred:'), error);
+      console.log(chalk.yellow('Exiting interactive mode.'));
+      process.exit(1);
     });
   }
 


### PR DESCRIPTION
## Summary
- Update docs/help for interactive mode flag (not '-i')
- Fix input truncation in interactive mode by implementing proper multiline input handling
- Update help to clarify 'q' is the recommended way to quit

## Test plan
1. Run `deslopify --help` to verify the correct flag documentation
2. Run `deslopify --interactive` and test multiline input by pasting text or entering line by line
3. Test quitting with 'q' and verify it works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)